### PR TITLE
ReputationFrame_Update();

### DIFF
--- a/Factionizer.lua
+++ b/Factionizer.lua
@@ -2955,7 +2955,7 @@ function FIZ_DumpReputationChangesToChat(initOnly)
 		end
 		-- choose Faction to show
 		SetWatchedFactionIndex(watchIndex)
-		ReputationWatchBar_Update(); -- rfl functions
+		ReputationFrame_Update(); -- rfl functions
 	end
 end
 


### PR DESCRIPTION
In legion ReputationWatchBar_Update was removed. simply changing to ReputationFrame_Update restores functionality.